### PR TITLE
Fix: Can't locate object method "new" via package "JSON" at t/cpanfile.t line 15.

### DIFF
--- a/t/cpanfile.t
+++ b/t/cpanfile.t
@@ -11,8 +11,7 @@ use Test::DZil;
     );
     $tzil->build;
 
-    my $json = $tzil->slurp_file('build/META.json');
-    my $meta = JSON->new->decode($json);
+    my $meta = $tzil->distmeta;
 
     is_deeply $meta->{prereqs}, {
         runtime => {


### PR DESCRIPTION
Also omits the JSON.pm prereq entirely, as we can simply test the meta structure directly.
